### PR TITLE
Add support for 'optional' keyword

### DIFF
--- a/pkg/proto/attribute.go
+++ b/pkg/proto/attribute.go
@@ -20,6 +20,7 @@ package proto
 type Attribute struct {
 	*Qualified
 	Repeated    bool
+	Optional    bool
 	Map         bool
 	Kind        []string
 	Ordinal     int
@@ -34,9 +35,11 @@ func (a *Attribute) IsValid() bool {
 // ToMermaid implements a Mermaid Syntax per Attribute
 func (a *Attribute) ToMermaid() string {
 	if a.Repeated {
-		return Join("", "+ List<", a.Kind[0], "> ", a.Name)
+		return Join("", "+ List~", a.Kind[0], "~ ", a.Name)
 	} else if a.Map {
-		return Join("", "+ Map<", a.Kind[0], ", ", a.Kind[1], "> ", a.Name)
+		return Join("", "+ Map~", a.Kind[0], ", ", a.Kind[1], "~ ", a.Name)
+	} else if a.Optional {
+		return Join("", "+ Optional~", a.Kind[0], "~ ", a.Name)
 	}
 	return Join(Space, "+", a.Kind[0], a.Name)
 }

--- a/pkg/proto/constants.go
+++ b/pkg/proto/constants.go
@@ -23,6 +23,7 @@ const (
 	PrefixRepeated = "repeated"
 	PrefixMap      = "map"
 	PrefixReserved = "reserved"
+	PrefixOptional = "optional"
 
 	SpaceRemovalRegex = `\s+`
 	Period            = "."

--- a/pkg/proto/writer_markdown.go
+++ b/pkg/proto/writer_markdown.go
@@ -72,6 +72,8 @@ func MessageToMarkdown(message *Message, visualize bool) (body string, diagram s
 			label = "Map"
 		} else if a.Repeated {
 			label = "Repeated"
+		} else if a.Optional {
+		    label = "Optional"
 		}
 		attributeTable.Insert(a.Name, strconv.Itoa(a.Ordinal), strings.Join(a.Kind, Comma), label, a.Comment.ToMarkdownText())
 	}


### PR DESCRIPTION
Hello!

I added support for the 'optional' keyword in the proto3 syntax. While it works on my proto example, I am not used to programming in Go and didn't add relevant tests. Would you still be able to consider this PR? Really appreciated!