### PR TITLE
Correct RpcVisitor to recognize the absence of `stream` in the Service return parameter

### DIFF
--- a/pkg/proto/rpc_visitor.go
+++ b/pkg/proto/rpc_visitor.go
@@ -53,7 +53,7 @@ func ParseReturnArgs(values []string, rpc *Rpc) {
 		if strings.HasPrefix(i, "stream") {
 			rpc.AddReturnParameter(NewParameter(true, strings.TrimSpace(i[strings.Index(i, Space):])))
 		} else {
-			rpc.AddReturnParameter(NewParameter(true, strings.TrimSpace(i)))
+			rpc.AddReturnParameter(NewParameter(false, strings.TrimSpace(i)))
 		}
 	}
 }


### PR DESCRIPTION
Currently, given a proto definition of a Unary (non-Stream) RPC call, 
```protobuf
service SomeService {
  rpc UnaryMethod(SomeRequest) returns (/* stream */SomeResponse) {}
}
```

`proto-gen-md-diagrams` emits a Mermaid.js diagram and a table showing that the type of the return parameter is not Unary but Stream, :

```mermaid
classDiagram
direction LR
class SomeService {
  <<service>>
  +UnaryMethod(SomeRequest) Stream~SomeResponse~
}
```

| Method                   | Parameter (In)                  | Parameter (Out)                            | Description                                                                              |
|--------------------------|---------------------------------|--------------------------------------------|------------------------------------------------------------------------------------------|
| UnaryMethod | SomeRequest | Stream\<SomeResponse\> | ...    |


This PR corrects `RpcVisitor.Visit()` to property handle the absence of a `stream` option in Service return parameters.

