### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or open a bug. Please follow the [Contributing](CONTRIBUTING.md) guidelines.
 ##### Using Native Go
 ```shell
 go build && go test ./...
-./proto-gen-md-diarams -d test/protos
+./proto-gen-md-diagrams -d test/protos
 ````
 
 ##### Using Bazel


### PR DESCRIPTION
Just a small typo but I tripped over it when copying from the instructions.