### PR TITLE
Fix recursive writing of output files - preserve folder structure

### DIFF
--- a/pkg/proto/app.go
+++ b/pkg/proto/app.go
@@ -84,10 +84,25 @@ func Execute() {
 
 	for _, pkg := range packages {
 		bName := filepath.Base(pkg.Path)
-    		out := *outputFlag + string(filepath.Separator) + bName + ".md"
+		// get the relative path to the protofile based on the input directory
+		fileRelativeToInputDir, err := filepath.Rel(*directoryFlag, pkg.Path)
+		if err != nil {
+			logger.Errorf("failed to get relative directory %vy\n", err)
+		}
+
+		relativeDir := filepath.Dir(fileRelativeToInputDir)
+		out := filepath.Join(*outputFlag, relativeDir, bName+".md")
 		markdown := PackageToMarkDown(pkg, config)
 
 		if *writeOutputFlag {
+			logger.Infof("Writing file: %v\n", out)
+
+			// we first have to ensure the directory exists before writing the file
+			err = os.MkdirAll(filepath.Dir(out), 0750)
+			if err != nil {
+				logger.Errorf("Could not create subdirectories", err)
+				return
+			}
 			err = os.WriteFile(out, []byte(markdown), 0644)
 		}
 		if err != nil {


### PR DESCRIPTION
When introducing the output flag, the input folder structure was not used in output.

Fixes https://github.com/GoogleCloudPlatform/proto-gen-md-diagrams/pull/14#issuecomment-2068571626

@chicco785  This fixes your comment