### PR TITLE
fix for annotation parsing

### DIFF
--- a/pkg/proto/annotation.go
+++ b/pkg/proto/annotation.go
@@ -36,8 +36,10 @@ func ParseAnnotations(in string) []*Annotation {
 	out := make([]*Annotation, 0)
 	if strings.Contains(in, OpenBracket) && strings.Contains(in, ClosedBracket) {
 		annotationString := in[strings.Index(in, OpenBracket)+1 : strings.Index(in, ClosedBracket)]
-		split := strings.Split(strings.ReplaceAll(annotationString, SingleQuote, Empty), Space)
-		out = append(out, NewAnnotation(split[0], split[2]))
+		split := strings.Split(strings.ReplaceAll(annotationString, SingleQuote, Empty), "=")
+		if len(split) > 1 {
+			out = append(out, NewAnnotation(strings.TrimSpace(split[0]), strings.TrimSpace(split[1])))
+		}
 	}
 	return out
 }

--- a/pkg/proto/annotation_test.go
+++ b/pkg/proto/annotation_test.go
@@ -51,6 +51,10 @@ func TestParseAnnotations(t *testing.T) {
 		want []*Annotation
 	}{
 		{name: "Test 001", args: args{in: "int32 longitude_degrees = 3 [json_name = 'lng_d'];"}, want: []*Annotation{{Name: "json_name", Value: "lng_d"}}},
+		// note that even if the source file declares the annotation with white space around `=` some pre-processor upstream of the annotation parser strips it
+		{name: "Test without whitespace", args: args{in: "optional uint32 weight = 18 [deprecated=true];"}, want: []*Annotation{{Name: "deprecated", Value: "true"}}},
+		// projects that import google/protobuf/timestamp.proto end up parsing the large comment block for annotation and runs into [toISOString()]. There must be another bug upstream, but the Annotation parser shall be protected too.
+		{name: "Test google.protobuf.timestamp.proto", args: args{in: "...using the // standard // [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) // method"}, want: []*Annotation{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Annotation parser did not handle `[deprecated = true]` due to some upstram preprocessing that strips the white space around ` = `.

Also, the assumption that splitting leads to exactly 3 token is not robust.
Due to some other bug in the upstream parser, the `google.protobuf.timestamp` ends up parsing the doc comment and the annotation parser chokes on the `[toISOString()](http://...)` link that looks to it like an annotation. I did not find why is it happening, but I protected the `Annotation` parser by checking the number of tokens after the splitting.